### PR TITLE
Add the sound engine file structure

### DIFF
--- a/app/javascript/components/pad/index.js
+++ b/app/javascript/components/pad/index.js
@@ -7,7 +7,7 @@ const CLASS_NAMES = {
 
 const template = document.createElement('template');
 template.innerHTML = `
-  <div class="pad__container p-4 rounded w-24 h-24 bg-accent-content text-accent hover:text-secondary hover:bg-secondary-content active:text-neutral active:bg-neutral-content">
+  <div class="pad__container">
     <div class="pad__text"></div>
   </div>
 `;

--- a/app/javascript/screens/base.js
+++ b/app/javascript/screens/base.js
@@ -19,7 +19,7 @@ template.innerHTML = `
   <div class="m-4 w-fit">
     <div class="flex">
       <div class="pad pad--option flex-2" id="pad_mode">Mode</div>
-      <div class="flex-1 w-48">
+      <div class="flex-1 w-48 px-4 py-2 m-2 rounded-full font-mono font-medium leading-none text-sm text-center text-primary bg-primary-content">
         <div id="display_mode">Mode...</div>
         <div id="display_instrument">Instrument...</div>
       </div>

--- a/app/javascript/screens/base.js
+++ b/app/javascript/screens/base.js
@@ -1,36 +1,53 @@
 import Pad, { DEFAULT_SELECTOR as PAD_SELECTOR } from '../components/pad/';
+import soundEngines from '../sound-engines';
 import { KeyMap } from '../utilities/keyMap';
 
 const SELECTORS = {
-  screen: '#base-screen'
+  screen: '#base-screen',
+
+  playPad: `${PAD_SELECTOR}.pad--play`,
+
+  padMode: '#pad_mode',
+  padInstrument: '#pad_instrument',
+
+  displayMode: '#display_mode',
+  displayInstrument: '#display_instrument'
 };
 
 const template = document.createElement('template');
 template.innerHTML = `
   <div class="m-4 w-fit">
     <div class="flex">
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_1"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_2"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_3"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_4"></div>
+      <div class="pad pad--option flex-2" id="pad_mode">Mode</div>
+      <div class="flex-1 w-48">
+        <div id="display_mode">Mode...</div>
+        <div id="display_instrument">Instrument...</div>
+      </div>
+      <div class="pad pad--option flex-2" id="pad_instrument">Instr.</div>
     </div>
     <div class="flex">
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_5"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_6"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_7"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_8"></div>
+      <div class="pad pad--play flex-1" id="pad_1"></div>
+      <div class="pad pad--play flex-1" id="pad_2"></div>
+      <div class="pad pad--play flex-1" id="pad_3"></div>
+      <div class="pad pad--play flex-1" id="pad_4"></div>
     </div>
     <div class="flex">
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_9"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_10"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_11"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_12"></div>
+      <div class="pad pad--play flex-1" id="pad_5"></div>
+      <div class="pad pad--play flex-1" id="pad_6"></div>
+      <div class="pad pad--play flex-1" id="pad_7"></div>
+      <div class="pad pad--play flex-1" id="pad_8"></div>
     </div>
     <div class="flex">
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_13"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_14"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_15"></div>
-      <div class="pad flex-1 first:ml-0 last:mr-0 m-2" id="pad_16"></div>
+      <div class="pad pad--play flex-1" id="pad_9"></div>
+      <div class="pad pad--play flex-1" id="pad_10"></div>
+      <div class="pad pad--play flex-1" id="pad_11"></div>
+      <div class="pad pad--play flex-1" id="pad_12"></div>
+    </div>
+    <div class="flex">
+      <div class="pad pad--play flex-1" id="pad_13"></div>
+      <div class="pad pad--play flex-1" id="pad_14"></div>
+      <div class="pad pad--play flex-1" id="pad_15"></div>
+      <div class="pad pad--play flex-1" id="pad_16"></div>
     </div>
   </div>
 `;
@@ -42,7 +59,13 @@ class BaseScreen {
     // Insert HTML content from template
     this.baseScreen.appendChild(template.content.cloneNode(true));
 
-    this.padsElements = Array.from(document.querySelectorAll(PAD_SELECTOR));
+    this.padsElements = Array.from(document.querySelectorAll(SELECTORS.playPad));
+    this.padInstrument = document.querySelector(SELECTORS.padInstrument);
+    this.padMode = document.querySelector(SELECTORS.padMode);
+    this.displayInstrument = document.querySelector(SELECTORS.displayInstrument);
+    this.displayMode = document.querySelector(SELECTORS.displayMode);
+
+    this.soundEngines = soundEngines;
 
     this._bind();
     this._setup();
@@ -56,13 +79,38 @@ class BaseScreen {
     }
   }
 
+  padModeOnClick() {
+    this.currentSoundEngineIndex++;
+
+    if (this.currentSoundEngineIndex >= this.soundEngines.length) {
+      this.currentSoundEngineIndex = 0;
+    }
+
+    this.currentSoundEngine = this.soundEngines[this.currentSoundEngineIndex];
+
+    this._refreshDisplays();
+  }
+
+  padInstrumentOnClick(e) {
+    if (this.currentSoundEngine.changeInstrument) {
+      this.currentSoundEngine.changeInstrument();
+
+      this._refreshDisplays();
+    }
+  }
+
   // Private
 
   _bind() {
     this.onKeyDown = this.onKeyDown.bind(this);
+    this.padModeOnClick = this.padModeOnClick.bind(this);
+    this.padInstrumentOnClick = this.padInstrumentOnClick.bind(this);
   }
 
   _setup() {
+    this.currentSoundEngineIndex = 0;
+    this.currentSoundEngine = this.soundEngines[this.currentSoundEngineIndex];
+
     this.pads = this.padsElements.map((padElement, i) => {
       const pad = new Pad(padElement);
       pad.setText(i);
@@ -72,14 +120,24 @@ class BaseScreen {
 
       return pad;
     });
+
+    this._refreshDisplays();
   }
 
   _addEventListeners() {
     document.addEventListener('keydown', this.onKeyDown);
+    this.padMode.addEventListener('click', this.padModeOnClick);
+    this.padInstrument.addEventListener('click', this.padInstrumentOnClick);
   }
 
   _onPadPlayed(padIndex) {
-    console.log(`Pad ${padIndex} pushed!`);
+    console.log(this.currentSoundEngine);
+    this.currentSoundEngine.onPadPressed(padIndex);
+  }
+
+  _refreshDisplays() {
+    this.displayMode.innerHTML = this.currentSoundEngine.name;
+    this.displayInstrument.innerHTML = this.currentSoundEngine.instrument;
   }
 }
 

--- a/app/javascript/sound-engines/index.js
+++ b/app/javascript/sound-engines/index.js
@@ -1,0 +1,9 @@
+import SamplerEngine from './sampler-engine';
+import WaveTableEngine from './wave-table-engine';
+
+const soundEngines = [];
+
+soundEngines.push(new WaveTableEngine());
+soundEngines.push(new SamplerEngine());
+
+export default soundEngines;

--- a/app/javascript/sound-engines/sampler-engine.js
+++ b/app/javascript/sound-engines/sampler-engine.js
@@ -1,0 +1,19 @@
+class SamplerEngine {
+  constructor() {
+    this.name = 'Sampler';
+    this.instrument = '-';
+  }
+
+  onPadPressed(padIndex) {
+    console.log(`Pad ${padIndex} pushed from the Sampler engine`);
+
+    // Implement here the logic to produce Sound based on the Pad Index (int)
+  }
+
+  changeInstrument() {
+    console.log('Changed instrument for the Sampler');
+    this.instrument = 'A new instrument!';
+  }
+}
+
+export default SamplerEngine;

--- a/app/javascript/sound-engines/wave-table-engine.js
+++ b/app/javascript/sound-engines/wave-table-engine.js
@@ -1,0 +1,19 @@
+class WaveTableEngine {
+  constructor() {
+    this.name = 'Wave Table';
+    this.instrument = '-';
+  }
+
+  onPadPressed(padIndex) {
+    console.log(`Pad ${padIndex} pushed from the Wave-table engine`);
+
+    // Implement here the logic to produce Sound based on the Pad Index (int)
+  }
+
+  changeInstrument() {
+    console.log('Changed instrument for the Wave Table');
+    this.instrument = 'A new instrument!';
+  }
+}
+
+export default WaveTableEngine;

--- a/app/styles/components/pad.css
+++ b/app/styles/components/pad.css
@@ -1,3 +1,18 @@
+.pad {
+  @apply p-4 rounded bg-accent-content text-accent;
+  @apply hover:text-secondary hover:bg-secondary-content;
+  @apply active:text-neutral active:bg-neutral-content;
+  @apply first:ml-0 last:mr-0 m-2;
+}
+
+.pad--play {
+  @apply h-24 w-24;
+}
+
+.pad--option {
+  @apply h-12 w-24;
+}
+
 .pad > .pad--pressed {
   @apply text-neutral bg-neutral-content;
   @apply hover:text-neutral hover:bg-neutral-content;


### PR DESCRIPTION
## Why?

This will make it easier for Mark/Palm to work in a clean file structure. This way we keep from adding the sound logic to the Base screen. Moreover, we can now switch the sound engines (MODE) and inside a sound engine, we can have variants (Instrument pad).

## Proof of Work:

https://user-images.githubusercontent.com/77609814/190991334-5139cd61-20dd-4091-a171-8d767b6d59c2.mov

### Add the style for the mini display

<img width="472" alt="image" src="https://user-images.githubusercontent.com/77609814/191152140-f507f1e2-5c8e-4bdb-8607-08abd211e9fa.png">

